### PR TITLE
Bump shiro-spring from 1.4.0 to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring</artifactId>
-            <version>1.4.0</version>
+            <version>1.7.1</version>
         </dependency>
 
         <!--commons工具包-->


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-spring dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>